### PR TITLE
Define `parse_errors` as `extern` in the header

### DIFF
--- a/parse.h
+++ b/parse.h
@@ -8,5 +8,5 @@ enum parse_errors_t {
 	EFERROR,
 };
 
-const char *parse_errors[];
+extern const char *parse_errors[];
 unsigned read_code(FILE *in, unsigned *line_count);


### PR DESCRIPTION
When defined as it is, it causes this build error:

/usr/bin/ld: geekcode.o:(.bss+0x0): multiple definition of `parse_errors'; parse.o:(.data.rel.local+0x0): first defined here

14 years later is as good time to fix a bug as any.
(I still want a parser for 3.1 / 3.2 versions...)